### PR TITLE
Change identifiers for consistency with omsba-web repo

### DIFF
--- a/@layout.latte
+++ b/@layout.latte
@@ -116,7 +116,7 @@
     <!-- /.container-fluid -->
 </nav>
 
-{define osmczmap}
+{define osmbamap}
     <div id="map-container">
         <div id="map-layers"></div>
         <div id="sidebar"></div>

--- a/defaultPage.latte
+++ b/defaultPage.latte
@@ -1,6 +1,6 @@
 {block title}{if $x=$page->getMeta('html-title')}{$x}{else}{$page[heading]}{/if}{/block}
 {block layout_aftertitle}{if $x=$page->getMeta('html-aftertitle')}{$x}{else}{include #parent}{/if}{/block}
-{block map}{include #osmczmap}{/block}
+{block map}{include #osmbamap}{/block}
 
 {block content}
 <div class="container" n:snippet="content">

--- a/splash.latte
+++ b/splash.latte
@@ -1,6 +1,6 @@
 {block title}OpenStreetMap.cz{/block}
 {block layout_aftertitle}{/block}
-{block map}{include #osmczmap}{/block}
+{block map}{include #osmbamap}{/block}
 
 {block content}
 <div class="container splash" {if $_SERVER['REQUEST_URI'] == '/splash'}style="display:block"{/if}>


### PR DESCRIPTION
Changed accordingly in https://github.com/osm-ba/osmba-web/pull/4 - don't merge until it's merged too.

Not strictly necessary but I suppose we'd better get rid of anything mentioning 'cz'
not to confuse any future maintainers.

Signed-off-by: Michal Fabik <michal.fabik@gmail.com>